### PR TITLE
Parse git output as utf-8, committer can haz ěščřžýáíé

### DIFF
--- a/rpm-spec-merge-driver
+++ b/rpm-spec-merge-driver
@@ -165,7 +165,7 @@ def get_changelog_header(version, release):
         ['git', 'commit-tree', '4b825dc642cb6eb9a060e54bf8d69288fbee4904'],
         check=True,
         stdout=subprocess.PIPE,
-        encoding='ascii',
+        encoding='utf-8',
         input='',
     )
     sha = proc.stdout.strip()
@@ -173,7 +173,7 @@ def get_changelog_header(version, release):
         ['git', 'show', '--pretty=format:%aD %aN <%aE>', sha],
         check=True,
         stdout=subprocess.PIPE,
-        encoding='ascii',
+        encoding='utf-8',
     )
     print(proc.stdout.strip())
     wd, day, mon, year, _, _, rest = proc.stdout.strip().split(' ', 6)


### PR DESCRIPTION
    Traceback (most recent call last):
      File "/home/churchyard/.local/bin/rpm-spec-merge-driver", line 213, in main
        new_entry = new_spec.changelog.squash(main_spec.changelog, max_version, release)
      File "/home/churchyard/.local/bin/rpm-spec-merge-driver", line 144, in squash
        header = get_changelog_header(version, release)
      File "/home/churchyard/.local/bin/rpm-spec-merge-driver", line 172, in get_changelog_header
        proc = subprocess.run(
      File "/usr/lib64/python3.8/subprocess.py", line 491, in run
        stdout, stderr = process.communicate(input, timeout=timeout)
      File "/usr/lib64/python3.8/subprocess.py", line 1011, in communicate
        stdout = self.stdout.read()
      File "/usr/lib64/python3.8/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 41: ordinal not in range(128)

Fixes https://github.com/encukou/rpm-spec-merge-driver/issues/1