### PR TITLE
Take author of the squashed changelog from the original change

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ A new header line is added using the author of the original change,
 the current date, and the new version and release.
 If more changelogs are merged in, the last one in the file
 (the first one chronologically) is used.
-The current date is overridable using `CURRENT_DATE` in a format
+The current date is overridable using `$CURRENT_DATE` in a format
 suitable for Python's `datetime.datetime.fromisoformat`, e.g.
-`YYYY-MM-DD HH:MM:SS`.
+`YYYY-MM-DD`.
 
 
 ## Tests
@@ -157,5 +157,4 @@ Run `pytest` for the tests.
 
 The tool is available under the MIT license, see `LICENSE.MIT`.
 May it serve you well.
-
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,13 @@ The MAIN's *new* part is added as-is.
 From NEW, the order of the *new* changelog blocks is reversed,
 the header lines are removed,
 and the content is added to the beginning of the changelog.
-A new header line is added,
-using the date, `user.name` and `user.email` as if you did a Git commit,
-and the new version and release.
+A new header line is added using the author of the original change,
+the current date, and the new version and release.
+If more changelogs are merged in, the last one in the file
+(the first one chronologically) is used.
+The current date is overridable using `CURRENT_DATE` in a format
+suitable for Python's `datetime.datetime.fromisoformat`, e.g.
+`YYYY-MM-DD HH:MM:SS`.
 
 
 ## Tests

--- a/rpm-spec-merge-driver
+++ b/rpm-spec-merge-driver
@@ -15,10 +15,20 @@ import email.utils
 VERSION_RE = re.compile(r'Version:(\s*)(\S*)')
 RELEASE_RE = re.compile(r'Release:(\s*)([0-9]*)%\{\?dist\}')
 CHANGELOG_RE = re.compile(
-    r'\*\s*(\w+)\s*(\w+)\s*(\d+)\s*(\d+)\s*([^<]+)<\s*([^>]+)>\s*-\s*(.*)',
-    re.DOTALL,
+    r'''
+        \*
+        \s*(?P<day_of_week>\w+)
+        \s*(?P<month>\w+)
+        \s*(?P<day>\d+)
+        \s*(?P<year>\d+)
+        \s*(?P<author>([^<]+)<\s*([^>]+)>)
+        \s*-\s*(?P<verrel>.*)
+    ''',
+    re.DOTALL | re.VERBOSE,
 )
 
+DAY_NAMES = 'Mon Tue Wed Thu Fri Sat Sun'.split()
+MONTH_NAMES = '- Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split()
 
 def trace(*args, **kwargs):
     kwargs.setdefault('file', sys.stderr)
@@ -112,7 +122,7 @@ class Changelog:
         for line in lines:
             stripped = line.strip()
             if not stripped and not entries:
-                whitespace_lines.append(line)
+                self.whitespace_lines.append(line)
                 continue
             if stripped == old_changelog_header:
                 entries = self.old_entries
@@ -141,8 +151,11 @@ class Changelog:
         The returned entry combines the contents of this changelog's
         new entries, and has a single fresh header line.
         """
-        header = get_changelog_header(version, release)
-        new_entry = ChangelogEntry(header, [header])
+        if not self.new_entries:
+            return None
+        author = CHANGELOG_RE.match(self.new_entries[-1].header)['author']
+        header = get_changelog_header(author, version, release)
+        new_entry = ChangelogEntry(header, [header], )
         for entry in reversed(self.new_entries):
             while not entry.lines[-1].strip():
                 entry.lines.pop()
@@ -152,33 +165,18 @@ class Changelog:
         return new_entry
 
 
-def get_changelog_header(version, release):
+def get_changelog_header(author, version, release):
     r"""Return a changelog header line
 
     The line is in the RPM spec changelog format, with \n at the end.
     """
-    # To make this work, we actually make a scratch commit
-    # (but don't put it on a branch), and read info from it.
-    proc = subprocess.run(
-        # The big number is the hash of an empty tree.
-        # It happens to be always available in a Git repo.
-        ['git', 'commit-tree', '4b825dc642cb6eb9a060e54bf8d69288fbee4904'],
-        check=True,
-        stdout=subprocess.PIPE,
-        encoding='utf-8',
-        input='',
-    )
-    sha = proc.stdout.strip()
-    proc = subprocess.run(
-        ['git', 'show', '--pretty=format:%aD %aN <%aE>', sha],
-        check=True,
-        stdout=subprocess.PIPE,
-        encoding='utf-8',
-    )
-    print(proc.stdout.strip())
-    wd, day, mon, year, _, _, rest = proc.stdout.strip().split(' ', 6)
-    wd = wd.strip(',')
-    return f'* {wd} {mon} {day} {year} {rest} - {version}-{release}\n'
+    if date_string := os.environ.get('CURRENT_DATE'):
+        date = datetime.datetime.fromisoformat(date_string)
+    else:
+        date = datetime.datetime.now()
+    wd = DAY_NAMES[date.weekday()]
+    month = MONTH_NAMES[date.month]
+    return f'* {wd} {month} {date.day} {date.year} {author} - {version}-{release}\n'
 
 
 def main(base, main, new, marker_size, pathname):

--- a/tests/cases/conflict
+++ b/tests/cases/conflict
@@ -78,7 +78,7 @@ Release: 1%{?dist}
 >>>>>>> new
 
 %changelog
-* Thu Aug 13 2020 Merge Driver 💁 <merger@example.org> - 2.0-1
+* Thu Aug 13 2020 Happy Packager <happy@example.org> - 2.0-1
 - Add a patch
 - Adjust the patch
 

--- a/tests/cases/multiauthor-changelog
+++ b/tests/cases/multiauthor-changelog
@@ -1,7 +1,7 @@
 OK
 -------- 8< --------
 
-Name: patch-vs-update
+Name: multiauthor-changelog
 
 Version: 1.0
 Release: 5%{?dist}
@@ -9,28 +9,6 @@ Release: 5%{?dist}
 ... Initial spec file content ...
 
 %changelog
-* Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
-- Fixed something
-
-* Tue May 31 2015 Happy Packager <happy@example.org> - 1.0-4
-- Hello world
-
-
--------- 8< --------
-
-Name: patch-vs-update
-
-Version: 1.0
-Release: 7%{?dist}
-
-... Patched spec file content ...
-
-%changelog
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.7
-- Adjust the patch
-
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.6
-- Add a patch
 
 * Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
 - Fixed something
@@ -41,7 +19,7 @@ Release: 7%{?dist}
 
 -------- 8< --------
 
-Name: patch-vs-update
+Name: multiauthor-changelog
 
 Version: 1.1
 Release: 2%{?dist}
@@ -49,7 +27,8 @@ Release: 2%{?dist}
 ... Initial spec file content ...
 
 %changelog
-* Tue May 31 2018 Happy Packager <happy@example.org> - 1.1-2
+
+* Tue May 31 2018 Serious Packager <serious@example.org> - 1.1-2
 - Add sources
 
 * Tue May 31 2017 Happy Packager <happy@example.org> - 1.1-1
@@ -64,23 +43,48 @@ Release: 2%{?dist}
 
 -------- 8< --------
 
-Name: patch-vs-update
+Name: multiauthor-changelog
 
-Version: 1.1
-Release: 2%{?dist}
+Version: 1.0
+Release: 7%{?dist}
 
 ... Patched spec file content ...
 
 %changelog
-* Thu Aug 13 2020 Happy Packager <happy@example.org> - 1.1-2
-- New upstream release
-- Add sources
 
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.7
+* Tue May 31 2019 Proven Packager <proven@example.org> - 1.0.7
 - Adjust the patch
 
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.6
+* Tue May 31 2019 Naïve Packager <naive@example.org> - 1.0.6
 - Add a patch
+
+* Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
+- Fixed something
+
+* Tue May 31 2015 Happy Packager <happy@example.org> - 1.0-4
+- Hello world
+
+
+-------- 8< --------
+
+Name: multiauthor-changelog
+
+Version: 1.1
+Release: 3%{?dist}
+
+... Patched spec file content ...
+
+%changelog
+
+* Thu Aug 13 2020 Naïve Packager <naive@example.org> - 1.1-3
+- Add a patch
+- Adjust the patch
+
+* Tue May 31 2018 Serious Packager <serious@example.org> - 1.1-2
+- Add sources
+
+* Tue May 31 2017 Happy Packager <happy@example.org> - 1.1-1
+- New upstream release
 
 * Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
 - Fixed something

--- a/tests/cases/no-new-changelog
+++ b/tests/cases/no-new-changelog
@@ -1,7 +1,7 @@
 OK
 -------- 8< --------
 
-Name: patch-vs-update
+Name: no-new-changelog
 
 Version: 1.0
 Release: 5%{?dist}
@@ -18,33 +18,10 @@ Release: 5%{?dist}
 
 -------- 8< --------
 
-Name: patch-vs-update
+Name: no-new-changelog
 
-Version: 1.0
-Release: 7%{?dist}
-
-... Patched spec file content ...
-
-%changelog
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.7
-- Adjust the patch
-
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.6
-- Add a patch
-
-* Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
-- Fixed something
-
-* Tue May 31 2015 Happy Packager <happy@example.org> - 1.0-4
-- Hello world
-
-
--------- 8< --------
-
-Name: patch-vs-update
-
-Version: 1.1
-Release: 2%{?dist}
+Version: 2.0
+Release: 1%{?dist}
 
 ... Initial spec file content ...
 
@@ -64,23 +41,36 @@ Release: 2%{?dist}
 
 -------- 8< --------
 
-Name: patch-vs-update
+Name: no-new-changelog
 
-Version: 1.1
+Version: 1.0
+Release: 5%{?dist}
+
+... Patched spec file content ...
+
+%changelog
+* Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
+- Fixed something
+
+* Tue May 31 2015 Happy Packager <happy@example.org> - 1.0-4
+- Hello world
+
+
+-------- 8< --------
+
+Name: no-new-changelog
+
+Version: 2.0
 Release: 2%{?dist}
 
 ... Patched spec file content ...
 
 %changelog
-* Thu Aug 13 2020 Happy Packager <happy@example.org> - 1.1-2
-- New upstream release
+* Tue May 31 2018 Happy Packager <happy@example.org> - 1.1-2
 - Add sources
 
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.7
-- Adjust the patch
-
-* Tue May 31 2019 Happy Packager <happy@example.org> - 1.0.6
-- Add a patch
+* Tue May 31 2017 Happy Packager <happy@example.org> - 1.1-1
+- New upstream release
 
 * Tue May 31 2016 Happy Packager <happy@example.org> - 1.0-5
 - Fixed something

--- a/tests/cases/update-vs-patch
+++ b/tests/cases/update-vs-patch
@@ -72,7 +72,7 @@ Release: 3%{?dist}
 ... Patched spec file content ...
 
 %changelog
-* Thu Aug 13 2020 Merge Driver 💁 <merger@example.org> - 1.1-3
+* Thu Aug 13 2020 Happy Packager <happy@example.org> - 1.1-3
 - Add a patch
 - Adjust the patch
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -29,7 +29,7 @@ def run(*argv, **kwargs):
     print(argv, file=sys.stderr)
     kwargs.setdefault('check', True)
     env = kwargs.setdefault('env', {})
-    env.setdefault('GIT_AUTHOR_DATE', '2020-08-13 12:34')
+    env.setdefault('CURRENT_DATE', '2020-08-13')
     env.setdefault('GIT_CONFIG_NOSYSTEM', '1')
     env.setdefault('HOME', CASES_PATH)
     env.setdefault('XDG_CONFIG_HOME', CASES_PATH)


### PR DESCRIPTION
Since the name is no longer taken from Git, we don't take the
date from git either. The mechanism to override the date (which
is there mainly for the tests) is changed to $CURRENT_DATE
(with a stricter format than what Git takes for AUTHOR_DATE).

Fixes: https://github.com/encukou/rpm-spec-merge-driver/issues/3